### PR TITLE
Filtering api

### DIFF
--- a/coralillo/core.py
+++ b/coralillo/core.py
@@ -139,6 +139,10 @@ class Form:
     def get_redis(cls):
         return cls.get_engine().redis
 
+# these return false if the value is null
+NULL_AFFECTED_FILTERS = ['lt', 'lte', 'gt', 'gte', 'startswith', 'endswith']
+# these ones don't give a shit about null values
+FILTERS = ['eq', 'ne'] + NULL_AFFECTED_FILTERS
 
 class QuerySet:
 
@@ -152,7 +156,8 @@ class QuerySet:
 
     def __next__(self):
         for item in self.iterator:
-            obj = self.cls(item)
+            obj = self.cls.get(debyte_string(item))
+
             if self.matches_filters(obj):
                 return obj
 
@@ -165,9 +170,54 @@ class QuerySet:
 
         return True
 
+    def make_filter(self, fieldname, query_func, expct_value):
+        ''' makes a filter that will be appliead to an object's property based
+        on query_func '''
+
+        def actual_filter(item):
+            value = getattr(item, fieldname)
+
+            if query_func in NULL_AFFECTED_FILTERS and value is None:
+                return False
+
+            if query_func == 'eq':
+                return value == expct_value
+            elif query_func == 'ne':
+                return value != expct_value
+            elif query_func == 'lt':
+                return value < expct_value
+            elif query_func == 'lte':
+                return value <= expct_value
+            elif query_func == 'gt':
+                return value > expct_value
+            elif query_func == 'gte':
+                return value >= expct_value
+            elif query_func == 'startswith':
+                return value.startswith(expct_value)
+            elif query_func == 'endswith':
+                return value.endswith(expct_value)
+
+        actual_filter.__doc__ = '{} {} {}'.format('val', query_func, expct_value)
+
+        return actual_filter
+
     def filter(self, **kwargs):
-        for key, value in kwargs:
-            pass
+        for key, value in kwargs.items():
+            try:
+                fieldname, query_func = key.split('__', 1)
+            except ValueError:
+                fieldname, query_func = key, 'eq'
+
+            if not hasattr(self.cls, fieldname):
+                raise AttributeError('Model {} does not have field {}'.format(
+                    self.cls.__name__,
+                    fieldname,
+                ))
+
+            if not query_func in FILTERS:
+                raise AttributeError('Filter {} does not exist'.format(query_func))
+
+            self.filters.append(self.make_filter(fieldname, query_func, value))
 
         return self
 

--- a/coralillo/core.py
+++ b/coralillo/core.py
@@ -4,6 +4,7 @@ from coralillo.datamodel import debyte_hash, debyte_string
 from coralillo.errors import ValidationErrors, UnboundModelError, BadField, ModelNotFoundError
 from coralillo.utils import to_pipeline, snake_case, parse_embed
 from coralillo.auth import PermissionHolder
+from coralillo.queryset import QuerySet
 from coralillo import Engine
 from itertools import starmap
 import json
@@ -138,88 +139,6 @@ class Form:
     @classmethod
     def get_redis(cls):
         return cls.get_engine().redis
-
-# these return false if the value is null
-NULL_AFFECTED_FILTERS = ['lt', 'lte', 'gt', 'gte', 'startswith', 'endswith']
-# these ones don't give a shit about null values
-FILTERS = ['eq', 'ne'] + NULL_AFFECTED_FILTERS
-
-class QuerySet:
-
-    def __init__(self, cls, iterator):
-        self.iterator = iterator
-        self.filters = []
-        self.cls = cls
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        for item in self.iterator:
-            obj = self.cls.get(debyte_string(item))
-
-            if self.matches_filters(obj):
-                return obj
-
-        raise StopIteration
-
-    def matches_filters(self, item):
-        for filt in self.filters:
-            if not filt(item):
-                return False
-
-        return True
-
-    def make_filter(self, fieldname, query_func, expct_value):
-        ''' makes a filter that will be appliead to an object's property based
-        on query_func '''
-
-        def actual_filter(item):
-            value = getattr(item, fieldname)
-
-            if query_func in NULL_AFFECTED_FILTERS and value is None:
-                return False
-
-            if query_func == 'eq':
-                return value == expct_value
-            elif query_func == 'ne':
-                return value != expct_value
-            elif query_func == 'lt':
-                return value < expct_value
-            elif query_func == 'lte':
-                return value <= expct_value
-            elif query_func == 'gt':
-                return value > expct_value
-            elif query_func == 'gte':
-                return value >= expct_value
-            elif query_func == 'startswith':
-                return value.startswith(expct_value)
-            elif query_func == 'endswith':
-                return value.endswith(expct_value)
-
-        actual_filter.__doc__ = '{} {} {}'.format('val', query_func, expct_value)
-
-        return actual_filter
-
-    def filter(self, **kwargs):
-        for key, value in kwargs.items():
-            try:
-                fieldname, query_func = key.split('__', 1)
-            except ValueError:
-                fieldname, query_func = key, 'eq'
-
-            if not hasattr(self.cls, fieldname):
-                raise AttributeError('Model {} does not have field {}'.format(
-                    self.cls.__name__,
-                    fieldname,
-                ))
-
-            if not query_func in FILTERS:
-                raise AttributeError('Filter {} does not exist'.format(query_func))
-
-            self.filters.append(self.make_filter(fieldname, query_func, value))
-
-        return self
 
 
 class Model(Form):

--- a/coralillo/fields.py
+++ b/coralillo/fields.py
@@ -1,12 +1,13 @@
-from .hashing import make_password, is_hashed
-from .errors import MissingFieldError, InvalidFieldError, ReservedFieldError, NotUniqueFieldError, DeleteRestrictedError
-from .datamodel import debyte_string, debyte_hash
 from . import datamodel
-from importlib import import_module
+from .datamodel import debyte_string, debyte_hash
+from .errors import MissingFieldError, InvalidFieldError, ReservedFieldError, NotUniqueFieldError, DeleteRestrictedError
+from .hashing import make_password, is_hashed
 from .utils import to_pipeline
-import re
+from coralillo.queryset import QuerySet
+from importlib import import_module
 import datetime
 import json
+import re
 
 
 class Field:
@@ -628,7 +629,10 @@ class MultipleRelation(Relation):
             getattr(value.proxy, self.inverse).unrelate(self.obj, redis)
 
     def count(self):
-        raise NotImplementedError('count is not implemented for this subclass of MultipleRelation')
+        raise NotImplementedError('count is not implemented yet for this subclass of MultipleRelation')
+
+    def q(self, **kwargs):
+        raise NotImplementedError('q is not implemented yet for this subclass of MultipleRelation')
 
 
 class SetRelation(MultipleRelation):
@@ -661,6 +665,12 @@ class SetRelation(MultipleRelation):
         redis = type(self.obj).get_redis()
 
         return redis.scard(key)
+
+    def q(self):
+        cls = type(self.obj)
+        redis = cls.get_redis()
+
+        return QuerySet(self.model(), redis.sscan_iter(self.key()))
 
     def __contains__(self, item):
         if not isinstance(item, self.model()):

--- a/coralillo/queryset.py
+++ b/coralillo/queryset.py
@@ -1,0 +1,84 @@
+from coralillo.datamodel import debyte_string
+
+# these return false if the value is null
+NULL_AFFECTED_FILTERS = ['lt', 'lte', 'gt', 'gte', 'startswith', 'endswith']
+# these ones don't give a shit about null values
+FILTERS = ['eq', 'ne'] + NULL_AFFECTED_FILTERS
+
+
+class QuerySet:
+
+    def __init__(self, cls, iterator):
+        self.iterator = iterator
+        self.filters = []
+        self.cls = cls
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        for item in self.iterator:
+            obj = self.cls.get(debyte_string(item))
+
+            if self.matches_filters(obj):
+                return obj
+
+        raise StopIteration
+
+    def matches_filters(self, item):
+        for filt in self.filters:
+            if not filt(item):
+                return False
+
+        return True
+
+    def make_filter(self, fieldname, query_func, expct_value):
+        ''' makes a filter that will be appliead to an object's property based
+        on query_func '''
+
+        def actual_filter(item):
+            value = getattr(item, fieldname)
+
+            if query_func in NULL_AFFECTED_FILTERS and value is None:
+                return False
+
+            if query_func == 'eq':
+                return value == expct_value
+            elif query_func == 'ne':
+                return value != expct_value
+            elif query_func == 'lt':
+                return value < expct_value
+            elif query_func == 'lte':
+                return value <= expct_value
+            elif query_func == 'gt':
+                return value > expct_value
+            elif query_func == 'gte':
+                return value >= expct_value
+            elif query_func == 'startswith':
+                return value.startswith(expct_value)
+            elif query_func == 'endswith':
+                return value.endswith(expct_value)
+
+        actual_filter.__doc__ = '{} {} {}'.format('val', query_func, expct_value)
+
+        return actual_filter
+
+    def filter(self, **kwargs):
+        for key, value in kwargs.items():
+            try:
+                fieldname, query_func = key.split('__', 1)
+            except ValueError:
+                fieldname, query_func = key, 'eq'
+
+            if not hasattr(self.cls, fieldname):
+                raise AttributeError('Model {} does not have field {}'.format(
+                    self.cls.__name__,
+                    fieldname,
+                ))
+
+            if not query_func in FILTERS:
+                raise AttributeError('Filter {} does not exist'.format(query_func))
+
+            self.filters.append(self.make_filter(fieldname, query_func, value))
+
+        return self

--- a/coralillo/tests/model_test.py
+++ b/coralillo/tests/model_test.py
@@ -32,6 +32,16 @@ def test_retrieve_by_index(nrm):
     assert titan == found_ship
 
 def test_filter(nrm):
+    with pytest.raises(AttributeError) as excinfo:
+        Pet.q().filter(legs__in=(3, 4))
+
+    assert str(excinfo.value) == 'Model Pet does not have field legs'
+
+    with pytest.raises(AttributeError) as excinfo:
+        Pet.q().filter(name__foo=True)
+
+    assert str(excinfo.value) == 'Filter foo does not exist'
+
     pets = [
         Pet(name='bc').save(), # 0
         Pet(name='bd').save(), # 1

--- a/coralillo/tests/model_test.py
+++ b/coralillo/tests/model_test.py
@@ -1,6 +1,7 @@
+from collections import Iterable
 from coralillo.datamodel import debyte_string
 from coralillo.errors import ModelNotFoundError
-from .models import House, Table, Ship, Tenanted, SideWalk
+from .models import House, Table, Ship, Tenanted, SideWalk, Pet
 import pytest
 
 def test_create_user(nrm):
@@ -29,6 +30,29 @@ def test_retrieve_by_index(nrm):
 
     assert found_ship is not None
     assert titan == found_ship
+
+def test_filter(nrm):
+    pets = [
+        Pet(name='bc').save(), # 0
+        Pet(name='bd').save(), # 1
+        Pet(name='cd').save(), # 2
+    ]
+
+    assert isinstance(Pet.q(), Iterable)
+
+    res = list(map(
+        lambda x:x.id,
+        Pet.q().filter(name__startswith='b', name__endswith='d')
+    ))
+
+    assert res == [pets[1].id]
+
+    res = list(map(
+        lambda x:x.id,
+        Pet.q().filter(name__startswith='b').filter(name__endswith='d')
+    ))
+
+    assert res == [pets[1].id]
 
 def test_update_keep_index(nrm):
     ship = Ship(name='the ship', code='TS').save()

--- a/coralillo/tests/relations_test.py
+++ b/coralillo/tests/relations_test.py
@@ -1,3 +1,4 @@
+from collections import Iterable
 from .models import Pet, Person, Driver, Car
 
 
@@ -98,6 +99,33 @@ def test_querying_related(nrm):
 
     assert u1 in o1.proxy.drivers
     assert u2 not in o1.proxy.drivers
+
+def test_can_filter_related(nrm):
+    p = Person(name='Juan').save()
+
+    pets = [
+        Pet(name='bc').save(), # 0
+        Pet(name='bd').save(), # 1
+        Pet(name='cd').save(), # 2
+    ]
+
+    p.proxy.pets.set(pets)
+
+    assert isinstance(p.proxy.pets.filter(name__startswith='pa'), Iterable)
+
+    res = list(map(
+        lambda x:x.id,
+        p.proxy.pets.filter(name__startswith='b', name__endswith='d')
+    ))
+
+    assert res == [pets[1].id]
+
+    res = list(map(
+        lambda x:x.id,
+        p.proxy.pets.filter(name__startswith='b').filter(name__endswith='d')
+    ))
+
+    assert res == [pets[1].id]
 
 def test_foreign_key(nrm):
     owner = Person(name='John').save()

--- a/coralillo/tests/relations_test.py
+++ b/coralillo/tests/relations_test.py
@@ -111,18 +111,18 @@ def test_can_filter_related(nrm):
 
     p.proxy.pets.set(pets)
 
-    assert isinstance(p.proxy.pets.filter(name__startswith='pa'), Iterable)
+    assert isinstance(p.proxy.pets.q().filter(name__startswith='pa'), Iterable)
 
     res = list(map(
         lambda x:x.id,
-        p.proxy.pets.filter(name__startswith='b', name__endswith='d')
+        p.proxy.pets.q().filter(name__startswith='b', name__endswith='d')
     ))
 
     assert res == [pets[1].id]
 
     res = list(map(
         lambda x:x.id,
-        p.proxy.pets.filter(name__startswith='b').filter(name__endswith='d')
+        p.proxy.pets.q().filter(name__startswith='b').filter(name__endswith='d')
     ))
 
     assert res == [pets[1].id]


### PR DESCRIPTION
Provides a way of filtering models and multiple relationships without the need of loading them all in memory. Uses redis SCAN via redis-py scan_iter methods.